### PR TITLE
EuroLinux 8 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # costos8migrate
 
-Puppet Helpers to Migrate from `CentOS 8` to `Alma Linux 8`, `Rocky Linux 8` or `CentOS 8 Stream`
+Puppet Helpers to Migrate from `CentOS 8` to `EuroLinux 8`, `Alma Linux 8`, `Rocky Linux 8` or `CentOS 8 Stream`
 
 ## WARNING: Use at your own risk. There is NO Support for this module.
 
@@ -58,6 +58,13 @@ I would recommend starting with this task to make sure your release is as up to 
 This task will convert CentOS 8 hosts to CentOSSteam, performing a reboot on completion.
 
 Estimated runtime for this task is ~17mins on a 2CPU, 2GB RAM minimal "Server with GUI installation" with access to a 1000MBit/s internet connection.
+
+
+### to_eurolinux
+
+This task will convert CentOS 8 hosts to EuroLinux 8, performing a reboot on completion.
+
+Estimated runtime for this task is ~26mins on a 2CPU, 2GB RAM minimal "Server with GUI installation" with access to a 1000MBit/s internet connection.
 
 
 ### to_alma_linux

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# costos8migrate
+# centos8migrate
 
 Puppet Helpers to Migrate from `CentOS 8` to `EuroLinux 8`, `Alma Linux 8`, `Rocky Linux 8` or `CentOS 8 Stream`
 

--- a/tasks/to_eurolinux.json
+++ b/tasks/to_eurolinux.json
@@ -1,0 +1,23 @@
+{
+    "description": "Migrate system from CentOS 8.5.2111 to EuroLinux 8",
+    "parameters": {
+        "stop_puppet": {
+            "description": "Stop the puppet periodic runs to they won't conflict.",
+            "type": "Boolean",
+            "default": true
+        },
+        "reboot": {
+            "description": "Reboot after migration tasks are complete.",
+            "type": "Boolean",
+            "default": true
+        }
+    },
+    "implementations": [
+        {
+            "name": "to_eurolinux.sh",
+            "requirements": [
+                "shell"
+            ]
+        }
+    ]
+}

--- a/tasks/to_eurolinux.sh
+++ b/tasks/to_eurolinux.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+# Check to make sure we are actually on a CentOS 8.5.2111 host
+if [ -f /etc/redhat-release ]; then 
+
+  RELEASE=`head -1 /etc/redhat-release`
+  if [[ "${RELEASE}" == "CentOS Linux release 8.5.2111" ]]; then
+    echo "Release: ${RELEASE}"
+
+    if [[ "${PT_stop_puppet}" == true ]]; then 
+        systemctl stop puppet
+    fi
+
+
+    cd /root
+    curl -O https://raw.githubusercontent.com/EuroLinux/eurolinux-migration-scripts/master/migrate2eurolinux.sh
+    curl -O https://raw.githubusercontent.com/EuroLinux/eurolinux-migration-scripts/master/remove_kernels.sh
+    
+    bash migrate2eurolinux.sh -f
+
+    dnf distro-sync -y 
+
+    if [[ "${PT_reboot}" == true ]]; then 
+      echo "Scheduling system restart in 1 minute..."
+      shutdown -r +1
+    fi
+
+  else 
+    echo "System is not CentOS Version 8.5.2111, please update prior to migration."
+  fi
+
+fi 
+


### PR DESCRIPTION
Add the support for migrating CentOS 8 to [EuroLinux 8](https://euro-linux.com/).